### PR TITLE
Fix #2: cross platform file operations + pass tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
     knitr,
+    R.utils,
     rmarkdown,
     utils
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Imports: 
+    fs,
     knitr,
     R.utils,
     tools,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,11 +19,11 @@ RoxygenNote: 7.3.2
 Imports: 
     knitr,
     R.utils,
-    rmarkdown,
     tools,
     utils,
     yaml
 Suggests: 
     curl,
+    rmarkdown,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     fs,
     knitr,
     R.utils,
-    tools,
     utils,
     yaml
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     R.utils,
     rmarkdown,
     utils
+    yaml
 Suggests: 
     curl,
     testthat (>= 3.0.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     knitr,
     R.utils,
     rmarkdown,
-    utils
+    tools,
+    utils,
     yaml
 Suggests: 
     curl,

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -28,10 +28,10 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
   md_name <- gsub(".Rmd$", "", basename(rmd_file))
 
   # Set input
-  if (grepl("^http", rmd_file)) {
+  if (R.utils::isUrl(rmd_file)) {
     # Correct mixed slash and backslash in file path (in Windows tempdir() uses
     # double backslashes as separator while file.path() uses regular slashes.)
-    tempdir <- gsub("\\\\", "/", tempdir())
+    temp_dir <- gsub("\\\\", "/", tempdir())
     if (dir.exists(tempdir)) {
       # create subdur in tempdir, so subdir is deleted when unlink is called and
       # not the whole tempdir folder

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -29,21 +29,24 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
 
   # Set input
   if (R.utils::isUrl(rmd_file)) {
-    # Correct mixed slash and backslash in file path (in Windows tempdir() uses
-    # double backslashes as separator while file.path() uses regular slashes.)
-    temp_dir <- gsub("\\\\", "/", tempdir())
-    if (dir.exists(tempdir)) {
-      # create subdur in tempdir, so subdir is deleted when unlink is called and
-      # not the whole tempdir folder
-      tempdir <- paste0(tempdir, "/rmd_file")
-      dir.create(tempdir)
-    }
-    input_file <- file.path(tempdir, basename(rmd_file))
-    utils::download.file(
-      rmd_file,
-      input_file
+    # Store the rmd_file in a subdir of the OS tempdir
+    temp_dir <- file.path(tempdir(), "rmd_file")
+    # Create the temp_dir if it doesn't exist from an earlier run
+    if(!dir.exists(temp_dir)){dir.create(temp_dir)}
+    temp_file <- tempfile(
+      basename(
+        tools::file_path_sans_ext(rmd_file)
+      ),
+      fileext = ".Rmd"
     )
+
+    utils::download.file(rmd_file,
+                         temp_file)
+
+    input_file <- temp_file
+
   } else {
+    # The file is local.
     input_file <- rmd_file
   }
 
@@ -90,5 +93,5 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
   knitr::opts_knit$set(original_opts_knit)
 
   # Empty the temporary directory
-  unlink(tempdir, recursive = TRUE)
+  unlink(temp_dir, recursive = TRUE)
 }

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -5,10 +5,11 @@
 #' added to the beginning of the Markdown file.
 #'
 #' @param rmd_file Path to the R Markdown file, either a local path or a URL.
-#' @param md_dir Path to local directory to Markdown file to.
+#' @param md_dir Path to local directory to Markdown file to. If it doesn't
+#'   exist it will be created.
 #' @param fig_dir Path to local directory to save figures to.
 #' @param fig_url_dir URL path that will be used to link to the figures in the
-#' markdown output.
+#'   markdown output.
 #' @param order Order of the article in the menu.
 #'
 #' @return Markdown file and figures written do disk.
@@ -25,25 +26,24 @@
 #' # Clean up (don't do this if you want to keep your files)
 #' unlink("output", recursive = TRUE)
 rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
-  md_name <- gsub(".Rmd$", "", basename(rmd_file))
+  # Get the basename of the input rmd_file without extension.
+  md_name <- fs::path_file(fs::path_ext_remove(rmd_file))
 
   # Set input
   if (R.utils::isUrl(rmd_file)) {
     # Store the rmd_file in a subdir of the OS tempdir
-    temp_dir <- file.path(tempdir(), "rmd_file")
+    temp_dir <- fs::path_temp("rmd_file")
     # Create the temp_dir if it doesn't exist from an earlier run
-    if(!dir.exists(temp_dir)){dir.create(temp_dir)}
-    temp_file <- tempfile(
-      basename(
-        tools::file_path_sans_ext(rmd_file)
-      ),
-      fileext = ".Rmd"
-    )
+    if(!fs::dir_exists(temp_dir)){fs::dir_create(temp_dir)}
+    temp_rmd_path <-
+      fs::file_temp(pattern = md_name,
+                    tmp_dir = temp_dir,
+                    ext = ".Rmd")
 
     utils::download.file(rmd_file,
-                         temp_file)
+                         temp_rmd_path)
 
-    input_file <- temp_file
+    input_file <- temp_rmd_path
 
   } else {
     # The file is local.
@@ -51,11 +51,12 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
   }
 
   # Set output
-  markdown_file <- file.path(md_dir, paste0(md_name, ".md"))
-
+  markdown_file <- fs::path_ext_set(
+    path = fs::path(md_dir, md_name),
+    ext = ".md")
   # Create directory for markdown file
-  if (!dir.exists(md_dir)) {
-    dir.create(md_dir, recursive = TRUE)
+  if (!fs::dir_exists(md_dir)) {
+    fs::dir_create(md_dir, recurse = TRUE)
   }
 
   # Save the original knitting options
@@ -92,6 +93,6 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
   # Reset knitting options to the original settings
   knitr::opts_knit$set(original_opts_knit)
 
-  # Empty the temporary directory
-  unlink(temp_dir, recursive = TRUE)
+  # Empty the temporary directory and it's contents
+  fs::dir_delete(temp_dir)
 }

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -51,7 +51,7 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, order) {
   }
 
   # Set output
-  markdown_file <- fs::path_ext_set(
+  md_file_path <- fs::path_ext_set(
     path = fs::path(md_dir, md_name),
     ext = ".md")
 

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -12,7 +12,7 @@ update_frontmatter <- function(file_path, original_file_path, order) {
   frontmatter <- yaml::yaml.load(frontmatter_char)
 
   # Update front matter
-  frontmatter$lastUpdated <- Sys.Date()
+  frontmatter$lastUpdated <- format(Sys.time(), "%Y-%M-%d")
   frontmatter$comment <- paste0("This file is generated from ", original_file_path, ". Please edit that file.")
   frontmatter$order <- order
   new_frontmatter <- yaml::as.yaml(frontmatter)

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -1,4 +1,6 @@
 update_frontmatter <- function(file_path, original_file_path, order) {
+  # Check that the required arguments are present
+  if(missing(order)){stop("The 'order' argument is required.")}
 
   # Transform original file path from raw to edit mode
   original_file_path <- gsub("raw.githubusercontent.com", "github.com", original_file_path)

--- a/man/rmd_to_md.Rd
+++ b/man/rmd_to_md.Rd
@@ -9,7 +9,8 @@ rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order)
 \arguments{
 \item{rmd_file}{Path to the R Markdown file, either a local path or a URL.}
 
-\item{md_dir}{Path to local directory to Markdown file to.}
+\item{md_dir}{Path to local directory to Markdown file to. If it doesn't
+exist it will be created.}
 
 \item{fig_dir}{Path to local directory to save figures to.}
 
@@ -32,7 +33,8 @@ rmd_file <- "https://raw.githubusercontent.com/b-cubed-eu/gcube/refs/heads/main/
 md_dir <- file.path("output", "src", "content", "docs", "software", "gcube")
 fig_dir <- file.path("output", "public", "software", "gcube")
 fig_url_dir <- "/software/gcube/"
-rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order = 1)
+order <- 1
+rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order)
 
 # Clean up (don't do this if you want to keep your files)
 unlink("output", recursive = TRUE)

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -8,7 +8,7 @@ test_that("rmd_to_md() writes .md to a directory", {
   fig_dir <- file.path(temp_dir, "public", "r", "gcube")
   fig_url_dir <- paste0(temp_dir, "/astro-docs/", "r", "gcube", "/")
 
-  rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir)
+  rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order = 1)
 
   expect_identical(
     list.files(md_dir),
@@ -66,7 +66,7 @@ test_that("rmd_to_md() resets knitting options to the original settings", {
   fig_url_dir <- paste0(temp_dir, "/astro-docs/r/gcube/")
 
   original_opts_knit <- knitr::opts_knit$get()
-  rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir)
+  rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order = 1)
   new_opts_knit <- knitr::opts_knit$get()
 
   expect_identical(original_opts_knit, new_opts_knit)
@@ -84,7 +84,7 @@ test_that("rmd_to_md() adds the current date to the beginning of the markdown fi
   fig_dir <- file.path(temp_dir, "public", "r", "gcube")
   fig_url_dir <- paste0(temp_dir, "/astro-docs/r/gcube/")
 
-  rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir)
+  rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order = 1)
 
   md_file <- file.path(md_dir, "occurrence-process.md")
   md_content <- readLines(md_file)

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -90,7 +90,7 @@ test_that("rmd_to_md() adds the current date to the beginning of the markdown fi
 
   expect_identical(
     rmarkdown::yaml_front_matter(md_file)$lastUpdated,
-    Sys.Date()
+    format(Sys.time(), "%Y-%M-%d")
   )
 
   unlink(temp_dir, recursive = TRUE)

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -87,10 +87,11 @@ test_that("rmd_to_md() adds the current date to the beginning of the markdown fi
   rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, order = 1)
 
   md_file <- file.path(md_dir, "occurrence-process.md")
-  md_content <- readLines(md_file)
-  expected_line <- paste0("Last update: ", Sys.Date())
 
-  expect_true(grepl(expected_line, md_content[1]))
+  expect_identical(
+    rmarkdown::yaml_front_matter(md_file)$lastUpdated,
+    Sys.Date()
+  )
 
   unlink(temp_dir, recursive = TRUE)
 })


### PR DESCRIPTION
I've made some changes to `rmd_to_md()` to solve the failing tests in #2. I've also changed  `update_frontmatter()` so it always uses the same date format when writing to the yaml header. 

I've introduced quite a few new imports, but most/all of these were already indirect imports of existing dependencies. 

`{fs}` is new, a Suggests from `{rmarkdown}`: https://fs.r-lib.org/, it handles consistent cross platform file operations. I think it's more readable and it'll avoid `//` issues between Windows and UNIX.

I also suggest using R.Utils for URL detection. 

Future improvements include increased coverage, using withr instead of unlink to avoid orphan files when the function fails and it can also handle more elegant knitr options resetting. As well as adding some checks on input arguments and documentation for `update_frontmatter()`. I didn't do a full review of #2

## AI Summary:

Dependency management:

* [`DESCRIPTION`](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cR20-R28): Added `fs`, `R.utils`, `tools`, and `yaml` to the `Imports` section and moved `rmarkdown` from `Imports` to `Suggests`.

Function enhancements:

* [`R/rmd_to_md.R`](diffhunk://#diff-c0300dbf3af0f4b2ad9147a6435196fd3c57bb937d9e57f376c9611e5ac55540L29-R60): Improved the `rmd_to_md` function to handle URLs more robustly by using the `fs` package for file operations and `R.utils` to check if the input is a URL.
* [`R/rmd_to_md.R`](diffhunk://#diff-c0300dbf3af0f4b2ad9147a6435196fd3c57bb937d9e57f376c9611e5ac55540L8-R9): Updated the documentation for `md_dir` parameter to indicate that the directory will be created if it doesn't exist.
* [`R/rmd_to_md.R`](diffhunk://#diff-c0300dbf3af0f4b2ad9147a6435196fd3c57bb937d9e57f376c9611e5ac55540L93-R98): Ensured the temporary directory is properly deleted after processing.

Date formatting:

* [`R/update_frontmatter.R`](diffhunk://#diff-f569d5dfc599bdccfc88751dadaecf7b1eda6ddeb0d95442d8b0cce989b000ecL15-R17): Modified the `update_frontmatter` function to format the `lastUpdated` field correctly using `Sys.time()`.

Testing improvements:

* [`tests/testthat/test-rmd_to_md.R`](diffhunk://#diff-6357ebd43d438bb235ba2b10a1b0556ca070da80315fcfa08af99d4dfc629c48L71-R101): Changed a test to ensure the `rmd_to_md` function adds the current date to the beginning of the markdown file.