### PR TITLE
Use ROR for copyright holder + link/shorten funder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-6658-6062", affiliation = "Research Institute for Nature and Forest (INBO)")),
     person("Research Institute for Nature and Forest (INBO)", role = "cph",
            comment = c(ROR = "00j54wy13")),
-     person("European Union's Horizon Europe Research and Innovation Programme", role = "fnd",
+    person("European Union", role = "fnd",
            comment = "https://doi.org/10.3030/101059592")
   )
 Description: What the package does (one paragraph).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Authors@R: c(
     person("Pieter", "Huybrechts", , "pieter.huybrechts@inbo.be", role = "aut",
            comment = c(ORCID = "0000-0002-6658-6062", affiliation = "Research Institute for Nature and Forest (INBO)")),
     person("Research Institute for Nature and Forest (INBO)", role = "cph",
-           comment = "https://www.vlaanderen.be/inbo/en-gb/"),
+           comment = c(ROR = "00j54wy13")),
     person("European Union's Horizon Europe Research and Innovation Programme (ID No 101059592)", role = "fnd")
   )
 Description: What the package does (one paragraph).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-6658-6062", affiliation = "Research Institute for Nature and Forest (INBO)")),
     person("Research Institute for Nature and Forest (INBO)", role = "cph",
            comment = c(ROR = "00j54wy13")),
-    person("European Union's Horizon Europe Research and Innovation Programme (ID No 101059592)", role = "fnd")
+     person("European Union's Horizon Europe Research and Innovation Programme", role = "fnd",
+           comment = "https://doi.org/10.3030/101059592")
   )
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE


### PR DESCRIPTION
[pkgdown 2.1.2](https://github.com/r-lib/pkgdown/releases/tag/v2.1.2) now supports ROR Identifiers for organizations. Since this supports better linked data, I think we should adopt it for our packages.

It will display on the pkgdown website as:

<img width="585" alt="Screenshot 2025-04-28 at 15 13 10" src="https://github.com/user-attachments/assets/3b4f44a8-760a-4316-9d37-9813b3792fa5" />

It might take a bit until GitHub Actions use pkgdown 2.1.2, so it will currently display as:

<img width="539" alt="Screenshot 2025-04-28 at 15 13 23" src="https://github.com/user-attachments/assets/13544ffe-b62a-4392-a99d-a82a9b8048a8" />

Eventually, this will resolve itself on future builds.