### PR TITLE
Add `replace` argument to `rmd_to_md()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,7 @@ Imports:
     fs,
     knitr,
     R.utils,
+    stringr,
     utils,
     yaml
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # b3doc (development version)
 
-* `update_frontmatter()` can now handle .md files (#20).
+* `update_frontmatter()` can now handle `.md` files (#20).
 * `update_frontmatter()` now has a `replace` argument that replaces all `key`s with their `value`. This argument now replaces argument `logo` (#22).
 
 # b3doc 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # b3doc (development version)
 
 * `update_frontmatter()` can now handle `.md` files (#20).
-* `update_frontmatter()` now has a `replace` argument that replaces all `key`s with their `value`. This argument now replaces argument `logo` (#22).
+* `update_frontmatter()` now has a `replace` argument that replaces all `key`s with their `value`. This argument replaces the `logo` argument (#22).
 
 # b3doc 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # b3doc (development version)
 
-* `update_frontmatter()` can now handle .md files (#19).
+* `update_frontmatter()` can now handle .md files (#20).
+* `update_frontmatter()` now has a `replace` argument that replaces all `key`s with their `value`. This argument now replaces argument `logo` (#22).
 
 # b3doc 0.1.0
 

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -31,8 +31,11 @@
 #'   title = "2. Occurrence process",
 #'   sidebar_label = "occurrence-process",
 #'   sidebar_order = 2,
-#'   replace = c("### Changing number of occurrences over time" =
-#'               "### How to change the number of occurrences over time")
+#'   replace = c(
+#'     "### Changing number of occurrences over time" =
+#'     "### How to change the number of occurrences over time",
+#'     "man/figures/logo.png" = "https://b-cubed-eu.github.io/gcube/logo.png"
+#'   )
 #' )
 #'
 #' # Clean up (don't do this if you want to keep your files)

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -37,7 +37,8 @@
 #' unlink("output", recursive = TRUE)
 #' }
 rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, title = NULL,
-                      sidebar_label = NULL, sidebar_order = NULL, logo = NULL) {
+                      sidebar_label = NULL, sidebar_order = NULL,
+                      replace = NULL) {
   # Get the basename of the input rmd_file without extension.
   md_name <- fs::path_file(fs::path_ext_remove(rmd_file))
 
@@ -103,7 +104,7 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, title = NULL,
     title = title,
     sidebar_label = sidebar_label,
     sidebar_order = sidebar_order,
-    logo = logo
+    replace = replace
   )
 
   # Reset knitting options to the original settings

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -30,7 +30,9 @@
 #'   fig_url_dir = "/software/gcube/",
 #'   title = "2. Occurrence process",
 #'   sidebar_label = "occurrence-process",
-#'   sidebar_order = 2
+#'   sidebar_order = 2,
+#'   replace = c("### Changing number of occurrences over time" =
+#'               "### How to change the number of occurrences over time")
 #' )
 #'
 #' # Clean up (don't do this if you want to keep your files)

--- a/R/rmd_to_md.R
+++ b/R/rmd_to_md.R
@@ -49,16 +49,15 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, title = NULL,
     # Store the rmd_file in a subdir of the OS tempdir
     temp_dir <- fs::path_temp("rmd_file")
     # Create the temp_dir if it doesn't exist from an earlier run
-    if (!fs::dir_exists(temp_dir)) {fs::dir_create(temp_dir)}
-    temp_rmd_path <-
-      fs::file_temp(pattern = md_name,
-                    tmp_dir = temp_dir,
-                    ext = ".Rmd")
+    if (!fs::dir_exists(temp_dir)) { fs::dir_create(temp_dir) }
+    temp_rmd_file <- fs::file_temp(
+      pattern = md_name,
+      tmp_dir = temp_dir,
+      ext = ".Rmd"
+    )
 
-    utils::download.file(rmd_file,
-                         temp_rmd_path)
-
-    input_file <- temp_rmd_path
+    utils::download.file(rmd_file, temp_rmd_file)
+    input_file <- temp_rmd_file
 
   } else {
     # The file is local.
@@ -66,9 +65,10 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, title = NULL,
   }
 
   # Set output
-  md_file_path <- fs::path_ext_set(
+  md_file <- fs::path_ext_set(
     path = fs::path(md_dir, md_name),
-    ext = ".md")
+    ext = ".md"
+  )
 
   # Create directory for markdown file
   if (!fs::dir_exists(md_dir)) {
@@ -96,12 +96,12 @@ rmd_to_md <- function(rmd_file, md_dir, fig_dir, fig_url_dir, title = NULL,
   # Knit
   knitr::knit(
     input = input_file,
-    output = md_file_path
+    output = md_file
   )
 
   # Update front matter
   update_frontmatter(
-    md_file_path,
+    md_file,
     rmd_file,
     title = title,
     sidebar_label = sidebar_label,

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -8,8 +8,8 @@
 #' @param sidebar_label Title in the sidebar.
 #' @param sidebar_order Number indicating the order of the article in the
 #'   sidebar.
-#' @param replace Set `key = value` pairs to replace all `key` strings by their
-#' `value`.
+#' @param replace Set `key = value` string pairs to replace all `key` strings
+#' by their `value`.
 #' @return Markdown file with updated front matter, written to disk.
 #' @examples
 #' \dontrun{
@@ -50,6 +50,16 @@ update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
         class = "b3doc_error_order_invalid"
       )
     }
+  }
+
+  if (!is.null(replace) && !is.character(replace)) {
+    cli::cli_abort(
+      c(
+        "{.arg replace} must be a string.",
+        "i" = "{.arg replace} is a {.cls {class(replace)}}."
+      ),
+      class = "b3doc_error_replace_invalid"
+    )
   }
 
   # Read markdown

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -2,8 +2,8 @@
 #'
 #' Updates the front matter (and optionally content) of a Markdown file on disk.
 #'
-#' @param md_file_path Path to the Markdown file on disk.
-#' @param rmd_file_path Path to the R Markdown file, either a local path or a
+#' @param md_file Path to the Markdown file on disk.
+#' @param rmd_file Path to the R Markdown file, either a local path or a
 #'   URL.
 #' @param title Title of the article, to show on top of the page.
 #' @param sidebar_label Title in the sidebar.
@@ -17,10 +17,10 @@
 #' @examples
 #' \dontrun{
 #' update_frontmatter(
-#'   md_file_path = file.path(
+#'   md_file = file.path(
 #'     "output/src/content/docs/software/gcube/occurrence-process.md"
 #'   ),
-#'   rmd_file_path = file.path(
+#'   rmd_file = file.path(
 #'     "https://raw.githubusercontent.com/b-cubed-eu/gcube/refs/heads/main",
 #'     "vignettes/articles/occurrence-process.Rmd"
 #'   ),
@@ -31,7 +31,7 @@
 #'               "### How to change the number of occurrences over time")
 #' )
 #' }
-update_frontmatter <- function(md_file_path, rmd_file_path, title = NULL,
+update_frontmatter <- function(md_file, rmd_file, title = NULL,
                                sidebar_label = NULL, sidebar_order = NULL,
                                replace = NULL) {
   if (!is.null(sidebar_order)) {
@@ -76,7 +76,7 @@ update_frontmatter <- function(md_file_path, rmd_file_path, title = NULL,
   }
 
   # Read markdown
-  lines <- readLines(md_file_path)
+  lines <- readLines(md_file)
 
   # Replace content
   if (!is.null(replace)) {
@@ -112,13 +112,11 @@ update_frontmatter <- function(md_file_path, rmd_file_path, title = NULL,
   if (!is.null(sidebar_order)) {
     frontmatter$sidebar$order <- as.integer(sidebar_order)
   }
-  if (R.utils::isUrl(rmd_file_path)) {
+  if (R.utils::isUrl(rmd_file)) {
     # Transform original file path from raw to edit mode to add as source
-    rmd_file_path <- gsub(
-      "raw.githubusercontent.com", "github.com", rmd_file_path
-    )
-    rmd_file_path <- gsub("/refs/heads/", "/blob/", rmd_file_path)
-    frontmatter$source <- rmd_file_path
+    rmd_file <- gsub("raw.githubusercontent.com", "github.com", rmd_file)
+    rmd_file <- gsub("/refs/heads/", "/blob/", rmd_file)
+    frontmatter$source <- rmd_file
   }
   new_frontmatter <- yaml::as.yaml(frontmatter)
   # as.yaml() converts the date to a string with quotes; remove quotes
@@ -136,5 +134,5 @@ update_frontmatter <- function(md_file_path, rmd_file_path, title = NULL,
   )
 
   # Write the updated file
-  writeLines(updated_lines, md_file_path)
+  writeLines(updated_lines, md_file)
 }

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -69,7 +69,7 @@ update_frontmatter <- function(md_file, rmd_file, title = NULL,
     cli::cli_abort(
       c(
         "{.arg replace} must be a named character vector.",
-        "i" = "Please provide c('key' = 'value') pairs."
+        "i" = "Please provide {.code c(\"key\" = \"value\")} pairs."
       ),
       class = "b3doc_error_replace_pairs"
     )

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -8,8 +8,8 @@
 #' @param sidebar_label Title in the sidebar.
 #' @param sidebar_order Number indicating the order of the article in the
 #'   sidebar.
-#' @param replace Set `key = value` string pairs to replace all `key` strings
-#' by their `value`.
+#' @param replace Named character vector indicating `key:value` pairs. All
+#' `key` strings are replaced by their `value`.
 #' @return Markdown file with updated front matter, written to disk.
 #' @examples
 #' \dontrun{
@@ -55,10 +55,20 @@ update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
   if (!is.null(replace) && !is.character(replace)) {
     cli::cli_abort(
       c(
-        "{.arg replace} must be a string.",
+        "{.arg replace} must be a named character vector.",
         "i" = "{.arg replace} is a {.cls {class(replace)}}."
       ),
-      class = "b3doc_error_replace_invalid"
+      class = "b3doc_error_replace_class"
+    )
+  }
+
+  if (!is.null(replace) && is.null(names(replace))) {
+    cli::cli_abort(
+      c(
+        "{.arg replace} must be a named character vector.",
+        "i" = "Please provide c('key' = 'value') pairs."
+      ),
+      class = "b3doc_error_replace_pairs"
     )
   }
 

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -3,7 +3,8 @@
 #' Updates the front matter and replaces the logo of a Markdown file on disk.
 #'
 #' @param md_file_path Path to the Markdown file on disk.
-#' @param rmd_file Path to the R Markdown file, either a local path or a URL.
+#' @param rmd_file_path Path to the R Markdown file, either a local path or a
+#'   URL.
 #' @param title Title of the article, to show on top of the page.
 #' @param sidebar_label Title in the sidebar.
 #' @param sidebar_order Number indicating the order of the article in the
@@ -17,7 +18,7 @@
 #'   md_file_path = file.path(
 #'     "output/src/content/docs/software/gcube/occurrence-process.md"
 #'   ),
-#'   rmd_file = file.path(
+#'   rmd_file_path = file.path(
 #'     "https://raw.githubusercontent.com/b-cubed-eu/gcube/refs/heads/main",
 #'     "vignettes/articles/occurrence-process.Rmd"
 #'   ),
@@ -28,7 +29,7 @@
 #'               "### How to change the number of occurrences over time")
 #' )
 #' }
-update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
+update_frontmatter <- function(md_file_path, rmd_file_path, title = NULL,
                                sidebar_label = NULL, sidebar_order = NULL,
                                replace = NULL) {
   if (!is.null(sidebar_order)) {
@@ -109,11 +110,13 @@ update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
   if (!is.null(sidebar_order)) {
     frontmatter$sidebar$order <- as.integer(sidebar_order)
   }
-  if (R.utils::isUrl(rmd_file)) {
+  if (R.utils::isUrl(rmd_file_path)) {
     # Transform original file path from raw to edit mode to add as source
-    rmd_file <- gsub("raw.githubusercontent.com", "github.com", rmd_file)
-    rmd_file <- gsub("/refs/heads/", "/blob/", rmd_file)
-    frontmatter$source <- rmd_file
+    rmd_file_path <- gsub(
+      "raw.githubusercontent.com", "github.com", rmd_file_path
+    )
+    rmd_file_path <- gsub("/refs/heads/", "/blob/", rmd_file_path)
+    frontmatter$source <- rmd_file_path
   }
   new_frontmatter <- yaml::as.yaml(frontmatter)
   # as.yaml() converts the date to a string with quotes; remove quotes

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -26,9 +26,12 @@
 #'   ),
 #'   title = "2. Occurrence process",
 #'   sidebar_label = "Occurrence process",
-#'   sidebar_order = 2;
-#'   replace = c("### Changing number of occurrences over time" =
-#'               "### How to change the number of occurrences over time")
+#'   sidebar_order = 2,
+#'   replace = c(
+#'     "### Changing number of occurrences over time" =
+#'     "### How to change the number of occurrences over time",
+#'     "man/figures/logo.png" = "https://b-cubed-eu.github.io/gcube/logo.png"
+#'   )
 #' )
 #' }
 update_frontmatter <- function(md_file, rmd_file, title = NULL,

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -8,7 +8,8 @@
 #' @param sidebar_label Title in the sidebar.
 #' @param sidebar_order Number indicating the order of the article in the
 #'   sidebar.
-#' @param logo URL to the logo file that replaces `"man/figures/logo.png"`.
+#' @param replace Set `key = value` pairs to replace all `key` strings by their
+#' `value`.
 #' @return Markdown file with updated front matter, written to disk.
 #' @examples
 #' \dontrun{
@@ -22,12 +23,14 @@
 #'   ),
 #'   title = "2. Occurrence process",
 #'   sidebar_label = "Occurrence process",
-#'   sidebar_order = 2
+#'   sidebar_order = 2;
+#'   replace = c("### Changing number of occurrences over time" =
+#'               "### How to change the number of occurrences over time")
 #' )
 #' }
 update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
                                sidebar_label = NULL, sidebar_order = NULL,
-                               logo = NULL) {
+                               replace = NULL) {
   if (!is.null(sidebar_order)) {
     if (!is.numeric(sidebar_order)) {
       cli::cli_abort(
@@ -53,8 +56,8 @@ update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
   lines <- readLines(md_file_path)
 
   # Replace logo URL
-  if (!is.null(logo)) {
-    lines <- gsub("man/figures/logo.png", logo, lines)
+  if (!is.null(replace)) {
+    lines <- stringr::str_replace_all(lines, replace)
   }
 
   # Read front matter
@@ -85,7 +88,7 @@ update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
   if (!is.null(sidebar_label)) {frontmatter$sidebar$label <- sidebar_label}
   if (!is.null(sidebar_order)) {
     frontmatter$sidebar$order <- as.integer(sidebar_order)
-    }
+  }
   if (R.utils::isUrl(rmd_file)) {
     # Transform original file path from raw to edit mode to add as source
     rmd_file <- gsub("raw.githubusercontent.com", "github.com", rmd_file)
@@ -96,7 +99,7 @@ update_frontmatter <- function(md_file_path, rmd_file, title = NULL,
   # as.yaml() converts the date to a string with quotes; remove quotes
   new_frontmatter <- gsub(
     "lastUpdated: '(.*)'", "lastUpdated: \\1", new_frontmatter
-    )
+  )
   # as.yaml() adds a a newline character at the end: remove newline
   new_frontmatter <- gsub("\n$", "", new_frontmatter)
 

--- a/R/update_frontmatter.R
+++ b/R/update_frontmatter.R
@@ -1,6 +1,6 @@
 #' Update front matter
 #'
-#' Updates the front matter and replaces the logo of a Markdown file on disk.
+#' Updates the front matter (and optionally content) of a Markdown file on disk.
 #'
 #' @param md_file_path Path to the Markdown file on disk.
 #' @param rmd_file_path Path to the R Markdown file, either a local path or a
@@ -9,9 +9,11 @@
 #' @param sidebar_label Title in the sidebar.
 #' @param sidebar_order Number indicating the order of the article in the
 #'   sidebar.
-#' @param replace Named character vector indicating `key:value` pairs. All
-#' `key` strings are replaced by their `value`.
-#' @return Markdown file with updated front matter, written to disk.
+#' @param replace Named character vector with `c("key" = "value")` pairs.
+#'   All occurrences of `"key"` in the content of the Markdown file will be
+#'   replaced by their respective `"value"` (before updating the front matter).
+#' @return Markdown file with updated front matter (and optionally content),
+#'   written to disk.
 #' @examples
 #' \dontrun{
 #' update_frontmatter(
@@ -76,7 +78,7 @@ update_frontmatter <- function(md_file_path, rmd_file_path, title = NULL,
   # Read markdown
   lines <- readLines(md_file_path)
 
-  # Replace logo URL
+  # Replace content
   if (!is.null(replace)) {
     lines <- stringr::str_replace_all(lines, replace)
   }

--- a/man/rmd_to_md.Rd
+++ b/man/rmd_to_md.Rd
@@ -62,8 +62,11 @@ rmd_to_md(
   title = "2. Occurrence process",
   sidebar_label = "occurrence-process",
   sidebar_order = 2,
-  replace = c("### Changing number of occurrences over time" =
-              "### How to change the number of occurrences over time")
+  replace = c(
+    "### Changing number of occurrences over time" =
+    "### How to change the number of occurrences over time",
+    "man/figures/logo.png" = "https://b-cubed-eu.github.io/gcube/logo.png"
+  )
 )
 
 # Clean up (don't do this if you want to keep your files)

--- a/man/rmd_to_md.Rd
+++ b/man/rmd_to_md.Rd
@@ -12,7 +12,7 @@ rmd_to_md(
   title = NULL,
   sidebar_label = NULL,
   sidebar_order = NULL,
-  logo = NULL
+  replace = NULL
 )
 }
 \arguments{
@@ -33,7 +33,8 @@ Markdown output.}
 \item{sidebar_order}{Number indicating the order of the article in the
 sidebar.}
 
-\item{logo}{URL to the logo file that replaces \code{"man/figures/logo.png"}.}
+\item{replace}{Set \code{key = value} pairs to replace all \code{key} strings by their
+\code{value}.}
 }
 \value{
 Markdown file and figures written do disk.

--- a/man/rmd_to_md.Rd
+++ b/man/rmd_to_md.Rd
@@ -33,8 +33,8 @@ Markdown output.}
 \item{sidebar_order}{Number indicating the order of the article in the
 sidebar.}
 
-\item{replace}{Set \code{key = value} pairs to replace all \code{key} strings by their
-\code{value}.}
+\item{replace}{Named character vector indicating \code{key:value} pairs. All
+\code{key} strings are replaced by their \code{value}.}
 }
 \value{
 Markdown file and figures written do disk.

--- a/man/rmd_to_md.Rd
+++ b/man/rmd_to_md.Rd
@@ -60,7 +60,9 @@ rmd_to_md(
   fig_url_dir = "/software/gcube/",
   title = "2. Occurrence process",
   sidebar_label = "occurrence-process",
-  sidebar_order = 2
+  sidebar_order = 2,
+  replace = c("### Changing number of occurrences over time" =
+              "### How to change the number of occurrences over time")
 )
 
 # Clean up (don't do this if you want to keep your files)

--- a/man/rmd_to_md.Rd
+++ b/man/rmd_to_md.Rd
@@ -33,8 +33,9 @@ Markdown output.}
 \item{sidebar_order}{Number indicating the order of the article in the
 sidebar.}
 
-\item{replace}{Named character vector indicating \code{key:value} pairs. All
-\code{key} strings are replaced by their \code{value}.}
+\item{replace}{Named character vector with \code{c("key" = "value")} pairs.
+All occurrences of \code{"key"} in the content of the Markdown file will be
+replaced by their respective \code{"value"} (before updating the front matter).}
 }
 \value{
 Markdown file and figures written do disk.

--- a/man/update_frontmatter.Rd
+++ b/man/update_frontmatter.Rd
@@ -5,8 +5,8 @@
 \title{Update front matter}
 \usage{
 update_frontmatter(
-  md_file_path,
-  rmd_file_path,
+  md_file,
+  rmd_file,
   title = NULL,
   sidebar_label = NULL,
   sidebar_order = NULL,
@@ -14,9 +14,9 @@ update_frontmatter(
 )
 }
 \arguments{
-\item{md_file_path}{Path to the Markdown file on disk.}
+\item{md_file}{Path to the Markdown file on disk.}
 
-\item{rmd_file_path}{Path to the R Markdown file, either a local path or a
+\item{rmd_file}{Path to the R Markdown file, either a local path or a
 URL.}
 
 \item{title}{Title of the article, to show on top of the page.}
@@ -40,10 +40,10 @@ Updates the front matter (and optionally content) of a Markdown file on disk.
 \examples{
 \dontrun{
 update_frontmatter(
-  md_file_path = file.path(
+  md_file = file.path(
     "output/src/content/docs/software/gcube/occurrence-process.md"
   ),
-  rmd_file_path = file.path(
+  rmd_file = file.path(
     "https://raw.githubusercontent.com/b-cubed-eu/gcube/refs/heads/main",
     "vignettes/articles/occurrence-process.Rmd"
   ),

--- a/man/update_frontmatter.Rd
+++ b/man/update_frontmatter.Rd
@@ -49,9 +49,12 @@ update_frontmatter(
   ),
   title = "2. Occurrence process",
   sidebar_label = "Occurrence process",
-  sidebar_order = 2;
-  replace = c("### Changing number of occurrences over time" =
-              "### How to change the number of occurrences over time")
+  sidebar_order = 2,
+  replace = c(
+    "### Changing number of occurrences over time" =
+    "### How to change the number of occurrences over time",
+    "man/figures/logo.png" = "https://b-cubed-eu.github.io/gcube/logo.png"
+  )
 )
 }
 }

--- a/man/update_frontmatter.Rd
+++ b/man/update_frontmatter.Rd
@@ -25,8 +25,8 @@ update_frontmatter(
 \item{sidebar_order}{Number indicating the order of the article in the
 sidebar.}
 
-\item{replace}{Set \code{key = value} pairs to replace all \code{key} strings by their
-\code{value}.}
+\item{replace}{Named character vector indicating \code{key:value} pairs. All
+\code{key} strings are replaced by their \code{value}.}
 }
 \value{
 Markdown file with updated front matter, written to disk.

--- a/man/update_frontmatter.Rd
+++ b/man/update_frontmatter.Rd
@@ -6,7 +6,7 @@
 \usage{
 update_frontmatter(
   md_file_path,
-  rmd_file,
+  rmd_file_path,
   title = NULL,
   sidebar_label = NULL,
   sidebar_order = NULL,
@@ -16,7 +16,8 @@ update_frontmatter(
 \arguments{
 \item{md_file_path}{Path to the Markdown file on disk.}
 
-\item{rmd_file}{Path to the R Markdown file, either a local path or a URL.}
+\item{rmd_file_path}{Path to the R Markdown file, either a local path or a
+URL.}
 
 \item{title}{Title of the article, to show on top of the page.}
 
@@ -25,14 +26,16 @@ update_frontmatter(
 \item{sidebar_order}{Number indicating the order of the article in the
 sidebar.}
 
-\item{replace}{Named character vector indicating \code{key:value} pairs. All
-\code{key} strings are replaced by their \code{value}.}
+\item{replace}{Named character vector with \code{c("key" = "value")} pairs.
+All occurrences of \code{"key"} in the content of the Markdown file will be
+replaced by their respective \code{"value"} (before updating the front matter).}
 }
 \value{
-Markdown file with updated front matter, written to disk.
+Markdown file with updated front matter (and optionally content),
+written to disk.
 }
 \description{
-Updates the front matter and replaces the logo of a Markdown file on disk.
+Updates the front matter (and optionally content) of a Markdown file on disk.
 }
 \examples{
 \dontrun{
@@ -40,7 +43,7 @@ update_frontmatter(
   md_file_path = file.path(
     "output/src/content/docs/software/gcube/occurrence-process.md"
   ),
-  rmd_file = file.path(
+  rmd_file_path = file.path(
     "https://raw.githubusercontent.com/b-cubed-eu/gcube/refs/heads/main",
     "vignettes/articles/occurrence-process.Rmd"
   ),

--- a/man/update_frontmatter.Rd
+++ b/man/update_frontmatter.Rd
@@ -10,7 +10,7 @@ update_frontmatter(
   title = NULL,
   sidebar_label = NULL,
   sidebar_order = NULL,
-  logo = NULL
+  replace = NULL
 )
 }
 \arguments{
@@ -25,7 +25,8 @@ update_frontmatter(
 \item{sidebar_order}{Number indicating the order of the article in the
 sidebar.}
 
-\item{logo}{URL to the logo file that replaces \code{"man/figures/logo.png"}.}
+\item{replace}{Set \code{key = value} pairs to replace all \code{key} strings by their
+\code{value}.}
 }
 \value{
 Markdown file with updated front matter, written to disk.
@@ -45,7 +46,9 @@ update_frontmatter(
   ),
   title = "2. Occurrence process",
   sidebar_label = "Occurrence process",
-  sidebar_order = 2
+  sidebar_order = 2;
+  replace = c("### Changing number of occurrences over time" =
+              "### How to change the number of occurrences over time")
 )
 }
 }

--- a/tests/testthat/_snaps/rmd_to_md/example.md
+++ b/tests/testthat/_snaps/rmd_to_md/example.md
@@ -13,18 +13,18 @@ sidebar:
 
 ## Let's start!
 
-The `rose` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rose flowers: *Rose setosa*, *Rose virginica*, and *Rose versicolor*.
+The `rosa` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rosa flowers: *Rosa setosa*, *Rosa virginica*, and *Rosa versicolor*.
 
 In this document, we will explore the dataset using base R functions.
 
-## The Rose Dataset
+## The Rosa Dataset
 
 First, let's take a look at the structure and a preview of the dataset.
 
 
 ``` r
 # Display the structure of the dataset
-str(rose)
+str(rosa)
 ```
 
 ```
@@ -38,7 +38,7 @@ str(rose)
 
 ``` r
 # Display the first few rows
-head(rose)
+head(rosa)
 ```
 
 ```
@@ -58,7 +58,7 @@ We can summarize the dataset to get an overview of the measurements for each var
 
 ``` r
 # Summary of the dataset
-summary(rose)
+summary(rosa)
 ```
 
 ```
@@ -80,20 +80,20 @@ summary(rose)
 
 ## Visualization: Sepal Length vs. Sepal Width
 
-We can visualize the relationship between sepal length and sepal width for the three species of rose flowers.
+We can visualize the relationship between sepal length and sepal width for the three species of rosa flowers.
 
 
 ``` r
 # Scatterplot of Sepal Length vs. Sepal Width
-plot(rose$Sepal.Length, rose$Sepal.Width,
-     col = as.numeric(rose$Species),
+plot(rosa$Sepal.Length, rosa$Sepal.Width,
+     col = as.numeric(rosa$Species),
      pch = 19,
      main = "Sepal Length vs Sepal Width",
      xlab = "Sepal Length (cm)",
      ylab = "Sepal Width (cm)")
 
 # Add a legend
-legend("topright", legend = levels(rose$Species),
+legend("topright", legend = levels(rosa$Species),
        col = 1:3, pch = 19, title = "Species")
 ```
 
@@ -106,7 +106,7 @@ Using base R, we can find the observation with the largest sepal length.
 
 ``` r
 # Find the observation with the largest sepal length
-largest_sepal <- rose[which.max(rose$Sepal.Length), ]
+largest_sepal <- rosa[which.max(rosa$Sepal.Length), ]
 largest_sepal
 ```
 
@@ -127,4 +127,4 @@ cat("The flower with the largest sepal length is from the species", largest_sepa
 
 ## Conclusion
 
-This document demonstrated how to use base R functions to explore and visualize the famous `rose` dataset. It is a great example for practicing data analysis and visualization with real-world data.
+This document demonstrated how to use base R functions to explore and visualize the famous `rosa` dataset. It is a great example for practicing data analysis and visualization with real-world data.

--- a/tests/testthat/_snaps/rmd_to_md/example.md
+++ b/tests/testthat/_snaps/rmd_to_md/example.md
@@ -11,20 +11,20 @@ sidebar:
 
 <img src="https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png" align="right" height="139" alt="Rmarkdown logo" /></a>
 
-## Introduction
+## Let's start!
 
-The `iris` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of iris flowers: *Iris setosa*, *Iris virginica*, and *Iris versicolor*.
+The `rose` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rose flowers: *Rose setosa*, *Rose virginica*, and *Rose versicolor*.
 
 In this document, we will explore the dataset using base R functions.
 
-## The Iris Dataset
+## The Rose Dataset
 
 First, let's take a look at the structure and a preview of the dataset.
 
 
 ``` r
 # Display the structure of the dataset
-str(iris)
+str(rose)
 ```
 
 ```
@@ -38,7 +38,7 @@ str(iris)
 
 ``` r
 # Display the first few rows
-head(iris)
+head(rose)
 ```
 
 ```
@@ -58,7 +58,7 @@ We can summarize the dataset to get an overview of the measurements for each var
 
 ``` r
 # Summary of the dataset
-summary(iris)
+summary(rose)
 ```
 
 ```
@@ -80,20 +80,20 @@ summary(iris)
 
 ## Visualization: Sepal Length vs. Sepal Width
 
-We can visualize the relationship between sepal length and sepal width for the three species of iris flowers.
+We can visualize the relationship between sepal length and sepal width for the three species of rose flowers.
 
 
 ``` r
 # Scatterplot of Sepal Length vs. Sepal Width
-plot(iris$Sepal.Length, iris$Sepal.Width,
-     col = as.numeric(iris$Species),
+plot(rose$Sepal.Length, rose$Sepal.Width,
+     col = as.numeric(rose$Species),
      pch = 19,
      main = "Sepal Length vs Sepal Width",
      xlab = "Sepal Length (cm)",
      ylab = "Sepal Width (cm)")
 
 # Add a legend
-legend("topright", legend = levels(iris$Species),
+legend("topright", legend = levels(rose$Species),
        col = 1:3, pch = 19, title = "Species")
 ```
 
@@ -106,7 +106,7 @@ Using base R, we can find the observation with the largest sepal length.
 
 ``` r
 # Find the observation with the largest sepal length
-largest_sepal <- iris[which.max(iris$Sepal.Length), ]
+largest_sepal <- rose[which.max(rose$Sepal.Length), ]
 largest_sepal
 ```
 
@@ -127,4 +127,4 @@ cat("The flower with the largest sepal length is from the species", largest_sepa
 
 ## Conclusion
 
-This document demonstrated how to use base R functions to explore and visualize the famous `iris` dataset. It is a great example for practicing data analysis and visualization with real-world data.
+This document demonstrated how to use base R functions to explore and visualize the famous `rose` dataset. It is a great example for practicing data analysis and visualization with real-world data.

--- a/tests/testthat/_snaps/rmd_to_md/example_md.md
+++ b/tests/testthat/_snaps/rmd_to_md/example_md.md
@@ -11,22 +11,22 @@ sidebar:
 
 <img src="https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png" align="right" height="139" alt="Rmarkdown logo" /></a>
 
-## Introduction
+## Let's start!
 
-The `iris` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of iris flowers: *Iris setosa*, *Iris virginica*, and *Iris versicolor*.
+The `rose` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rose flowers: *Rose setosa*, *Rose virginica*, and *Rose versicolor*.
 
 In this document, we will explore the dataset using base R functions.
 
-## The Iris Dataset
+## The Rose Dataset
 
 First, let's take a look at the structure and a preview of the dataset.
 
 ```r
 # Display the structure of the dataset
-str(iris)
+str(rose)
 
 # Display the first few rows
-head(iris)
+head(rose)
 ```
 
 ## Summary Statistics
@@ -35,24 +35,24 @@ We can summarize the dataset to get an overview of the measurements for each var
 
 ```r
 # Summary of the dataset
-summary(iris)
+summary(rose)
 ```
 
 ## Visualization: Sepal Length vs. Sepal Width
 
-We can visualize the relationship between sepal length and sepal width for the three species of iris flowers.
+We can visualize the relationship between sepal length and sepal width for the three species of rose flowers.
 
 ```r
 # Scatterplot of Sepal Length vs. Sepal Width
-plot(iris$Sepal.Length, iris$Sepal.Width,
-     col = as.numeric(iris$Species),
+plot(rose$Sepal.Length, rose$Sepal.Width,
+     col = as.numeric(rose$Species),
      pch = 19,
      main = "Sepal Length vs Sepal Width",
      xlab = "Sepal Length (cm)",
      ylab = "Sepal Width (cm)")
 
 # Add a legend
-legend("topright", legend = levels(iris$Species),
+legend("topright", legend = levels(rose$Species),
        col = 1:3, pch = 19, title = "Species")
 ```
 
@@ -62,7 +62,7 @@ Using base R, we can find the observation with the largest sepal length.
 
 ```r
 # Find the observation with the largest sepal length
-largest_sepal <- iris[which.max(iris$Sepal.Length), ]
+largest_sepal <- rose[which.max(rose$Sepal.Length), ]
 largest_sepal
 
 # Display a fun fact
@@ -72,4 +72,4 @@ cat("The flower with the largest sepal length is from the species", largest_sepa
 
 ## Conclusion
 
-This document demonstrated how to use base R functions to explore and visualize the famous `iris` dataset. It is a great example for practicing data analysis and visualization with real-world data.
+This document demonstrated how to use base R functions to explore and visualize the famous `rose` dataset. It is a great example for practicing data analysis and visualization with real-world data.

--- a/tests/testthat/_snaps/rmd_to_md/example_md.md
+++ b/tests/testthat/_snaps/rmd_to_md/example_md.md
@@ -13,20 +13,20 @@ sidebar:
 
 ## Let's start!
 
-The `rose` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rose flowers: *Rose setosa*, *Rose virginica*, and *Rose versicolor*.
+The `rosa` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rosa flowers: *Rosa setosa*, *Rosa virginica*, and *Rosa versicolor*.
 
 In this document, we will explore the dataset using base R functions.
 
-## The Rose Dataset
+## The Rosa Dataset
 
 First, let's take a look at the structure and a preview of the dataset.
 
 ```r
 # Display the structure of the dataset
-str(rose)
+str(rosa)
 
 # Display the first few rows
-head(rose)
+head(rosa)
 ```
 
 ## Summary Statistics
@@ -35,24 +35,24 @@ We can summarize the dataset to get an overview of the measurements for each var
 
 ```r
 # Summary of the dataset
-summary(rose)
+summary(rosa)
 ```
 
 ## Visualization: Sepal Length vs. Sepal Width
 
-We can visualize the relationship between sepal length and sepal width for the three species of rose flowers.
+We can visualize the relationship between sepal length and sepal width for the three species of rosa flowers.
 
 ```r
 # Scatterplot of Sepal Length vs. Sepal Width
-plot(rose$Sepal.Length, rose$Sepal.Width,
-     col = as.numeric(rose$Species),
+plot(rosa$Sepal.Length, rosa$Sepal.Width,
+     col = as.numeric(rosa$Species),
      pch = 19,
      main = "Sepal Length vs Sepal Width",
      xlab = "Sepal Length (cm)",
      ylab = "Sepal Width (cm)")
 
 # Add a legend
-legend("topright", legend = levels(rose$Species),
+legend("topright", legend = levels(rosa$Species),
        col = 1:3, pch = 19, title = "Species")
 ```
 
@@ -62,7 +62,7 @@ Using base R, we can find the observation with the largest sepal length.
 
 ```r
 # Find the observation with the largest sepal length
-largest_sepal <- rose[which.max(rose$Sepal.Length), ]
+largest_sepal <- rosa[which.max(rosa$Sepal.Length), ]
 largest_sepal
 
 # Display a fun fact
@@ -72,4 +72,4 @@ cat("The flower with the largest sepal length is from the species", largest_sepa
 
 ## Conclusion
 
-This document demonstrated how to use base R functions to explore and visualize the famous `rose` dataset. It is a great example for practicing data analysis and visualization with real-world data.
+This document demonstrated how to use base R functions to explore and visualize the famous `rosa` dataset. It is a great example for practicing data analysis and visualization with real-world data.

--- a/tests/testthat/_snaps/rmd_to_md/example_md_nofront.md
+++ b/tests/testthat/_snaps/rmd_to_md/example_md_nofront.md
@@ -10,20 +10,20 @@ sidebar:
 
 ## Let's start!
 
-The `rose` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rose flowers: *Rose setosa*, *Rose virginica*, and *Rose versicolor*.
+The `rosa` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rosa flowers: *Rosa setosa*, *Rosa virginica*, and *Rosa versicolor*.
 
 In this document, we will explore the dataset using base R functions.
 
-## The Rose Dataset
+## The Rosa Dataset
 
 First, let's take a look at the structure and a preview of the dataset.
 
 ```r
 # Display the structure of the dataset
-str(rose)
+str(rosa)
 
 # Display the first few rows
-head(rose)
+head(rosa)
 ```
 
 ## Summary Statistics
@@ -32,24 +32,24 @@ We can summarize the dataset to get an overview of the measurements for each var
 
 ```r
 # Summary of the dataset
-summary(rose)
+summary(rosa)
 ```
 
 ## Visualization: Sepal Length vs. Sepal Width
 
-We can visualize the relationship between sepal length and sepal width for the three species of rose flowers.
+We can visualize the relationship between sepal length and sepal width for the three species of rosa flowers.
 
 ```r
 # Scatterplot of Sepal Length vs. Sepal Width
-plot(rose$Sepal.Length, rose$Sepal.Width,
-     col = as.numeric(rose$Species),
+plot(rosa$Sepal.Length, rosa$Sepal.Width,
+     col = as.numeric(rosa$Species),
      pch = 19,
      main = "Sepal Length vs Sepal Width",
      xlab = "Sepal Length (cm)",
      ylab = "Sepal Width (cm)")
 
 # Add a legend
-legend("topright", legend = levels(rose$Species),
+legend("topright", legend = levels(rosa$Species),
        col = 1:3, pch = 19, title = "Species")
 ```
 
@@ -59,7 +59,7 @@ Using base R, we can find the observation with the largest sepal length.
 
 ```r
 # Find the observation with the largest sepal length
-largest_sepal <- rose[which.max(rose$Sepal.Length), ]
+largest_sepal <- rosa[which.max(rosa$Sepal.Length), ]
 largest_sepal
 
 # Display a fun fact
@@ -69,4 +69,4 @@ cat("The flower with the largest sepal length is from the species", largest_sepa
 
 ## Conclusion
 
-This document demonstrated how to use base R functions to explore and visualize the famous `rose` dataset. It is a great example for practicing data analysis and visualization with real-world data.
+This document demonstrated how to use base R functions to explore and visualize the famous `rosa` dataset. It is a great example for practicing data analysis and visualization with real-world data.

--- a/tests/testthat/_snaps/rmd_to_md/example_md_nofront.md
+++ b/tests/testthat/_snaps/rmd_to_md/example_md_nofront.md
@@ -8,22 +8,22 @@ sidebar:
 
 <img src="https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png" align="right" height="139" alt="Rmarkdown logo" /></a>
 
-## Introduction
+## Let's start!
 
-The `iris` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of iris flowers: *Iris setosa*, *Iris virginica*, and *Iris versicolor*.
+The `rose` dataset is a classic dataset in the field of statistics and machine learning. It contains measurements of sepal length, sepal width, petal length, and petal width for three species of rose flowers: *Rose setosa*, *Rose virginica*, and *Rose versicolor*.
 
 In this document, we will explore the dataset using base R functions.
 
-## The Iris Dataset
+## The Rose Dataset
 
 First, let's take a look at the structure and a preview of the dataset.
 
 ```r
 # Display the structure of the dataset
-str(iris)
+str(rose)
 
 # Display the first few rows
-head(iris)
+head(rose)
 ```
 
 ## Summary Statistics
@@ -32,24 +32,24 @@ We can summarize the dataset to get an overview of the measurements for each var
 
 ```r
 # Summary of the dataset
-summary(iris)
+summary(rose)
 ```
 
 ## Visualization: Sepal Length vs. Sepal Width
 
-We can visualize the relationship between sepal length and sepal width for the three species of iris flowers.
+We can visualize the relationship between sepal length and sepal width for the three species of rose flowers.
 
 ```r
 # Scatterplot of Sepal Length vs. Sepal Width
-plot(iris$Sepal.Length, iris$Sepal.Width,
-     col = as.numeric(iris$Species),
+plot(rose$Sepal.Length, rose$Sepal.Width,
+     col = as.numeric(rose$Species),
      pch = 19,
      main = "Sepal Length vs Sepal Width",
      xlab = "Sepal Length (cm)",
      ylab = "Sepal Width (cm)")
 
 # Add a legend
-legend("topright", legend = levels(iris$Species),
+legend("topright", legend = levels(rose$Species),
        col = 1:3, pch = 19, title = "Species")
 ```
 
@@ -59,7 +59,7 @@ Using base R, we can find the observation with the largest sepal length.
 
 ```r
 # Find the observation with the largest sepal length
-largest_sepal <- iris[which.max(iris$Sepal.Length), ]
+largest_sepal <- rose[which.max(rose$Sepal.Length), ]
 largest_sepal
 
 # Display a fun fact
@@ -69,4 +69,4 @@ cat("The flower with the largest sepal length is from the species", largest_sepa
 
 ## Conclusion
 
-This document demonstrated how to use base R functions to explore and visualize the famous `iris` dataset. It is a great example for practicing data analysis and visualization with real-world data.
+This document demonstrated how to use base R functions to explore and visualize the famous `rose` dataset. It is a great example for practicing data analysis and visualization with real-world data.

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -19,17 +19,6 @@ test_that("rmd_to_md() returns error on invalid parameters", {
       md_dir = md_dir,
       fig_dir = fig_dir,
       fig_url_dir = fig_url_dir,
-      sidebar_order = "invalid"
-    ),
-    class = "b3doc_error_order_invalid"
-  )
-
-  expect_error(
-    rmd_to_md(
-      rmd_file = rmd_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
       sidebar_order = "1"
     ),
     class = "b3doc_error_order_invalid"
@@ -53,17 +42,6 @@ test_that("rmd_to_md() returns error on invalid parameters", {
       md_dir = md_dir,
       fig_dir = fig_dir,
       fig_url_dir = fig_url_dir,
-      sidebar_order = "invalid"
-    ),
-    class = "b3doc_error_order_invalid"
-  )
-
-  expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
       sidebar_order = "1"
     ),
     class = "b3doc_error_order_invalid"
@@ -81,17 +59,6 @@ test_that("rmd_to_md() returns error on invalid parameters", {
   )
 
   # Test md without front matter
-  expect_error(
-    rmd_to_md(
-      rmd_file = md_nofront_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = "invalid"
-    ),
-    class = "b3doc_error_order_invalid"
-  )
-
   expect_error(
     rmd_to_md(
       rmd_file = md_nofront_file,

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -171,7 +171,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     title = "Custom title",
     sidebar_label = "Custom sidebar label",
     sidebar_order = 2,
-    logo = "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+    replace = c(
+      "man/figures/logo.png" =
+      "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+    )
   )
 
   expect_snapshot_file(
@@ -190,7 +193,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     title = "Custom title",
     sidebar_label = "Custom sidebar label",
     sidebar_order = 2,
-    logo = "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+    replace = c(
+      "man/figures/logo.png" =
+        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+    )
   )
 
   expect_snapshot_file(
@@ -209,7 +215,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     title = "Custom title",
     sidebar_label = "Custom sidebar label",
     sidebar_order = 2,
-    logo = "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+    replace = c(
+      "man/figures/logo.png" =
+        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+    )
   )
 
   expect_snapshot_file(
@@ -228,7 +237,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     title = "Introduction",
     sidebar_label = "Introduction",
     sidebar_order = 1,
-    logo = "https://b-cubed-eu.github.io/dubicube/logo.png"
+    replace = c(
+      "man/figures/logo.png" =
+        "https://b-cubed-eu.github.io/dubicube/logo.png"
+    )
   )
 
   expect_snapshot_file(

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -1,4 +1,4 @@
-test_that("rmd_to_md() returns error on invalid sidebar_order", {
+test_that("rmd_to_md() returns error on invalid parameters", {
   temp_dir <- tempdir()
   on.exit(unlink(temp_dir, recursive = TRUE))
 
@@ -9,6 +9,8 @@ test_that("rmd_to_md() returns error on invalid sidebar_order", {
   md_dir <- file.path(temp_dir, "src/content/docs/software/example")
   fig_dir <- file.path(temp_dir, "public/software/example")
   fig_url_dir <- "/software/example/"
+
+  # 1. Sidebar order
 
   # Test Rmd with front matter
   expect_error(
@@ -110,6 +112,43 @@ test_that("rmd_to_md() returns error on invalid sidebar_order", {
       sidebar_order = 1.1
     ),
     class = "b3doc_error_order_invalid"
+  )
+
+  # 2. Replace
+  # Test Rmd with front matter
+  expect_error(
+    rmd_to_md(
+      rmd_file = rmd_file,
+      md_dir = md_dir,
+      fig_dir = fig_dir,
+      fig_url_dir = fig_url_dir,
+      replace = list("one" = "1", "two" = "2")
+    ),
+    class = "b3doc_error_replace_invalid"
+  )
+
+  # Test md with front matter
+  expect_error(
+    rmd_to_md(
+      rmd_file = md_file,
+      md_dir = md_dir,
+      fig_dir = fig_dir,
+      fig_url_dir = fig_url_dir,
+      replace = data.frame("one" = "1", "two" = "2")
+    ),
+    class = "b3doc_error_replace_invalid"
+  )
+
+  # Test md with front matter
+  expect_error(
+    rmd_to_md(
+      rmd_file = md_file,
+      md_dir = md_dir,
+      fig_dir = fig_dir,
+      fig_url_dir = fig_url_dir,
+      replace = list("one", "two", "three")
+    ),
+    class = "b3doc_error_replace_invalid"
   )
 })
 

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -1,153 +1,78 @@
 test_that("rmd_to_md() returns error on invalid parameters", {
   temp_dir <- tempdir()
   on.exit(unlink(temp_dir, recursive = TRUE))
-
   rmd_file <- testthat::test_path("example.Rmd")
   md_file <- testthat::test_path("example_md.md")
-  md_nofront_file <- testthat::test_path("example_md_nofront.md")
-
+  md_nf_file <- testthat::test_path("example_md_nofront.md")
   md_dir <- file.path(temp_dir, "src/content/docs/software/example")
   fig_dir <- file.path(temp_dir, "public/software/example")
   fig_url_dir <- "/software/example/"
 
   # 1. Sidebar order
-
-  # Test Rmd with front matter
   expect_error(
-    rmd_to_md(
-      rmd_file = rmd_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = "1"
-    ),
+    rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, sidebar_order = "1"),
+    class = "b3doc_error_order_invalid"
+  )
+  expect_error(
+    rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, sidebar_order = 1.1),
     class = "b3doc_error_order_invalid"
   )
 
   expect_error(
-    rmd_to_md(
-      rmd_file = rmd_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = 1.1
-    ),
+    rmd_to_md(md_file, md_dir, fig_dir, fig_url_dir, sidebar_order = "1"),
     class = "b3doc_error_order_invalid"
   )
-
-  # Test md with front matter
   expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = "1"
-    ),
+    rmd_to_md(md_file, md_dir, fig_dir, fig_url_dir, sidebar_order = 1.1),
     class = "b3doc_error_order_invalid"
   )
 
   expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = 1.1
-    ),
+    rmd_to_md(md_nf_file, md_dir, fig_dir, fig_url_dir, sidebar_order = "1"),
     class = "b3doc_error_order_invalid"
   )
-
-  # Test md without front matter
   expect_error(
-    rmd_to_md(
-      rmd_file = md_nofront_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = "1"
-    ),
-    class = "b3doc_error_order_invalid"
-  )
-
-  expect_error(
-    rmd_to_md(
-      rmd_file = md_nofront_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      sidebar_order = 1.1
-    ),
+    rmd_to_md(md_nf_file, md_dir, fig_dir, fig_url_dir, sidebar_order = 1.1),
     class = "b3doc_error_order_invalid"
   )
 
   # 2. Replace
-  # Test Rmd with front matter
   expect_error(
-    rmd_to_md(
-      rmd_file = rmd_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      replace = list("one" = "1", "two" = "2")
-    ),
+    rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, replace = list("a" = "b")),
     class = "b3doc_error_replace_class"
   )
-
   expect_error(
-    rmd_to_md(
-      rmd_file = rmd_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      replace = c("one", "two")
-    ),
+    rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, replace = data.frame()),
+    class = "b3doc_error_replace_class"
+  )
+  expect_error(
+    rmd_to_md(rmd_file, md_dir, fig_dir, fig_url_dir, replace = c("a", "b")),
     class = "b3doc_error_replace_pairs"
   )
 
-  # Test md with front matter
   expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      replace = data.frame("one" = "1", "two" = "2")
-    ),
+    rmd_to_md(md_file, md_dir, fig_dir, fig_url_dir, replace = list("a" = "b")),
     class = "b3doc_error_replace_class"
   )
-
   expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      replace = c("one", "two")
-    ),
+    rmd_to_md(md_file, md_dir, fig_dir, fig_url_dir, replace = data.frame()),
+    class = "b3doc_error_replace_class"
+  )
+  expect_error(
+    rmd_to_md(md_file, md_dir, fig_dir, fig_url_dir, replace = c("a", "b")),
     class = "b3doc_error_replace_pairs"
   )
 
-  # Test md with front matter
   expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      replace = list("one", "two", "three")
-    ),
+    rmd_to_md(md_nf_file, md_dir, fig_dir, fig_url_dir, replace = list("a" = "b")),
     class = "b3doc_error_replace_class"
   )
-
   expect_error(
-    rmd_to_md(
-      rmd_file = md_file,
-      md_dir = md_dir,
-      fig_dir = fig_dir,
-      fig_url_dir = fig_url_dir,
-      replace = c("one", "two")
-    ),
+    rmd_to_md(md_nf_file, md_dir, fig_dir, fig_url_dir, replace = data.frame()),
+    class = "b3doc_error_replace_class"
+  )
+  expect_error(
+    rmd_to_md(md_nf_file, md_dir, fig_dir, fig_url_dir, replace = c("a", "b")),
     class = "b3doc_error_replace_pairs"
   )
 })
@@ -195,7 +120,7 @@ test_that("rmd_to_md() writes .md and figures to the expected directories", {
   )
 })
 
-test_that("rmd_to_md() writes the expected markdown, including custom
+test_that("rmd_to_md() writes the expected Markdown, including custom
            frontmatter and figure paths", {
   temp_dir <- tempdir()
   expected_md_dir <- file.path(temp_dir, "src/content/docs/software/example")
@@ -211,8 +136,7 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_label = "Custom sidebar label",
     sidebar_order = 2,
     replace = c(
-      "man/figures/logo.png" =
-      "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
+      "man/figures/logo.png" = "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
       "## Introduction" = "## Let's start!",
       "Iris" = "Rosa",
       "iris" = "rosa"
@@ -236,8 +160,7 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_label = "Custom sidebar label",
     sidebar_order = 2,
     replace = c(
-      "man/figures/logo.png" =
-        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
+      "man/figures/logo.png" = "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
       "## Introduction" = "## Let's start!",
       "Iris" = "Rosa",
       "iris" = "rosa"
@@ -261,8 +184,7 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_label = "Custom sidebar label",
     sidebar_order = 2,
     replace = c(
-      "man/figures/logo.png" =
-        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
+      "man/figures/logo.png" = "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
       "## Introduction" = "## Let's start!",
       "Iris" = "Rosa",
       "iris" = "rosa"
@@ -286,8 +208,7 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_label = "Introduction",
     sidebar_order = 1,
     replace = c(
-      "man/figures/logo.png" =
-        "https://b-cubed-eu.github.io/dubicube/logo.png",
+      "man/figures/logo.png" = "https://b-cubed-eu.github.io/dubicube/logo.png",
       "## Introduction" = "## Let's start!",
       "Iris" = "Rosa",
       "iris" = "rosa"

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -173,7 +173,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_order = 2,
     replace = c(
       "man/figures/logo.png" =
-      "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+      "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
+      "## Introduction" = "## Let's start!",
+      "Iris" = "Rose",
+      "iris" = "rose"
     )
   )
 
@@ -195,7 +198,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_order = 2,
     replace = c(
       "man/figures/logo.png" =
-        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
+      "## Introduction" = "## Let's start!",
+      "Iris" = "Rose",
+      "iris" = "rose"
     )
   )
 
@@ -217,7 +223,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_order = 2,
     replace = c(
       "man/figures/logo.png" =
-        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png"
+        "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
+      "## Introduction" = "## Let's start!",
+      "Iris" = "Rose",
+      "iris" = "rose"
     )
   )
 
@@ -239,7 +248,10 @@ test_that("rmd_to_md() writes the expected markdown, including custom
     sidebar_order = 1,
     replace = c(
       "man/figures/logo.png" =
-        "https://b-cubed-eu.github.io/dubicube/logo.png"
+        "https://b-cubed-eu.github.io/dubicube/logo.png",
+      "## Introduction" = "## Let's start!",
+      "Iris" = "Rose",
+      "iris" = "rose"
     )
   )
 

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -175,8 +175,8 @@ test_that("rmd_to_md() writes the expected markdown, including custom
       "man/figures/logo.png" =
       "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
       "## Introduction" = "## Let's start!",
-      "Iris" = "Rose",
-      "iris" = "rose"
+      "Iris" = "Rosa",
+      "iris" = "rosa"
     )
   )
 
@@ -200,8 +200,8 @@ test_that("rmd_to_md() writes the expected markdown, including custom
       "man/figures/logo.png" =
         "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
       "## Introduction" = "## Let's start!",
-      "Iris" = "Rose",
-      "iris" = "rose"
+      "Iris" = "Rosa",
+      "iris" = "rosa"
     )
   )
 
@@ -225,8 +225,8 @@ test_that("rmd_to_md() writes the expected markdown, including custom
       "man/figures/logo.png" =
         "https://pkgs.rstudio.com/rmarkdown/reference/figures/logo.png",
       "## Introduction" = "## Let's start!",
-      "Iris" = "Rose",
-      "iris" = "rose"
+      "Iris" = "Rosa",
+      "iris" = "rosa"
     )
   )
 
@@ -250,8 +250,8 @@ test_that("rmd_to_md() writes the expected markdown, including custom
       "man/figures/logo.png" =
         "https://b-cubed-eu.github.io/dubicube/logo.png",
       "## Introduction" = "## Let's start!",
-      "Iris" = "Rose",
-      "iris" = "rose"
+      "Iris" = "Rosa",
+      "iris" = "rosa"
     )
   )
 

--- a/tests/testthat/test-rmd_to_md.R
+++ b/tests/testthat/test-rmd_to_md.R
@@ -91,7 +91,18 @@ test_that("rmd_to_md() returns error on invalid parameters", {
       fig_url_dir = fig_url_dir,
       replace = list("one" = "1", "two" = "2")
     ),
-    class = "b3doc_error_replace_invalid"
+    class = "b3doc_error_replace_class"
+  )
+
+  expect_error(
+    rmd_to_md(
+      rmd_file = rmd_file,
+      md_dir = md_dir,
+      fig_dir = fig_dir,
+      fig_url_dir = fig_url_dir,
+      replace = c("one", "two")
+    ),
+    class = "b3doc_error_replace_pairs"
   )
 
   # Test md with front matter
@@ -103,7 +114,18 @@ test_that("rmd_to_md() returns error on invalid parameters", {
       fig_url_dir = fig_url_dir,
       replace = data.frame("one" = "1", "two" = "2")
     ),
-    class = "b3doc_error_replace_invalid"
+    class = "b3doc_error_replace_class"
+  )
+
+  expect_error(
+    rmd_to_md(
+      rmd_file = md_file,
+      md_dir = md_dir,
+      fig_dir = fig_dir,
+      fig_url_dir = fig_url_dir,
+      replace = c("one", "two")
+    ),
+    class = "b3doc_error_replace_pairs"
   )
 
   # Test md with front matter
@@ -115,7 +137,18 @@ test_that("rmd_to_md() returns error on invalid parameters", {
       fig_url_dir = fig_url_dir,
       replace = list("one", "two", "three")
     ),
-    class = "b3doc_error_replace_invalid"
+    class = "b3doc_error_replace_class"
+  )
+
+  expect_error(
+    rmd_to_md(
+      rmd_file = md_file,
+      md_dir = md_dir,
+      fig_dir = fig_dir,
+      fig_url_dir = fig_url_dir,
+      replace = c("one", "two")
+    ),
+    class = "b3doc_error_replace_pairs"
   )
 })
 


### PR DESCRIPTION
fix #17 

This parameter allows to replace strings, and help with removing titles, updating links to static images, etc.

- [x] User provides a set of `key = value` pairs in `replace`

```R
replace = c(
  "figures/bootstrapping.png" = "https://b-cubed-eu.github.io/dubicube/articles/figures/bootstrapping.png",
  "^# dubicube " = ""
)
```

- [x] After conversion to md, all `key` strings in the text are replaced by their `value`
- [x] The `logo` parameter is removed in favour of this.

This is also a solution for:

- fix #14 
- fix #18 